### PR TITLE
fix: use decoder/encoder types from it-length-prefixed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,24 +24,14 @@ export interface ProtobufStream {
   unwrap: () => Duplex<Uint8Array>
 }
 
-export interface LengthDecoderFunction {
-  (data: Uint8ArrayList): number
-  bytes: number
-}
-
-export interface LengthEncoderFunction {
-  (value: number, target: Uint8ArrayList, offset: number): Uint8ArrayList
-  bytes: number
-}
-
 export interface Opts {
   // encoding opts
   poolSize: number
   minPoolSize: number
-  lengthEncoder: LengthEncoderFunction
+  lengthEncoder: lp.LengthEncoderFunction
 
   // decoding opts
-  lengthDecoder: LengthDecoderFunction
+  lengthDecoder: lp.LengthDecoderFunction
   maxLengthLength: number
   maxDataLength: number
 }

--- a/test/fixtures/int32BE-decode.ts
+++ b/test/fixtures/int32BE-decode.ts
@@ -1,4 +1,4 @@
-import type { LengthDecoderFunction } from '../../src/index.js'
+import type { LengthDecoderFunction } from 'it-length-prefixed'
 
 export const int32BEDecode: LengthDecoderFunction = (data) => {
   if (data.length < 4) {

--- a/test/fixtures/int32BE-encode.ts
+++ b/test/fixtures/int32BE-encode.ts
@@ -1,5 +1,5 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import type { LengthEncoderFunction } from '../../src/index.js'
+import type { LengthEncoderFunction } from 'it-length-prefixed'
 
 export const int32BEEncode: LengthEncoderFunction = (value) => {
   const data = new Uint8ArrayList(


### PR DESCRIPTION
Remove duplicate interfaces