### PR TITLE
fix!: derive unwrapped stream type from input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export interface Encoder<T> {
 }
 
 /**
- * Convinience methods for working with protobuf streams
+ * Convenience methods for working with protobuf streams
  */
 export interface ProtobufStream <TSink> {
   /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -65,7 +65,7 @@ Object.keys(tests).forEach(key => {
   const test = tests[key]
 
   describe(`it-pb-rpc ${key}`, () => {
-    let w: ProtobufStream
+    let w: ProtobufStream<Uint8Array>
 
     before(async () => {
       w = pbStream(pair<Uint8Array>())


### PR DESCRIPTION
The passed stream is wrapped in `it-handshake` which can derive the
unrwapped type from the input.  This module assumes TSink will be
`Uint8Array` which may not be the case.

Instead, derive the unwrapped stream type from the input, though it's
meant needing to make the `ProtobufStream` type generic which may
trip up certain use cases (declaring a `ProtobufStream` variable, for
example) so this is a breaking change.

BREAKING CHANGE: ProtobufStream is now generic