### PR TITLE
fix: close pushable after sink ends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,8 @@ export function pbStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
     for await (const buf of source) {
       write.push(buf)
     }
+
+    write.end()
   }
 
   let source = duplex.source


### PR DESCRIPTION
Otherwise the wrapped stream will never end.